### PR TITLE
Added support for subvolume snap shotting

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -97,10 +97,10 @@ cnt=$(( $3+1 ))
 # Verify that the path is either a valid btrfs mountpoint
 mount -t btrfs | cut -d " " -f 3 | grep "^${mp}$" > /dev/null
 if [ $? -ne 0 ] ; then
-        # or a valid snapshot with the same ending as ${mp}
-        btrfs subvolume list ${mp} | grep "${mp##*/}$" > /dev/null
+        # or a valid snapshot matching mp
+        btrfs subvolume show $mp | grep "${mp}$" > /dev/null
         if [ $? -ne 0 ] ; then
-                echo "Error: ${mp} is not a btrfs mountpoint"
+                echo "Error: ${mp} is not a btrfs mountpoint (or old version of btrfs-tools, try > 0.19)"
                 exit 1
         fi
 fi


### PR DESCRIPTION
In the current master branch btrfs-snap will not create a backup of a nested subvolume. The proposed changes add support for subvolumes by querying for subvolumes located in the specified mountpoint. If `btrfs subvolume list ${mp$}` returns an entry which matches the end of `${mp}` it is a valid subvolume.
