### PR TITLE
Use bash pattern matching to remove tailing slash

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -176,7 +176,7 @@ if [ $# -ne 3 ] ; then
 fi
 
 # Remove trailing slash
-mp=$(echo $1 | perl -pe 's#([^/])/$#$1#')
+mp=${1%/}
 prefix=$2
 cnt=$(( $3+1 ))
 


### PR DESCRIPTION
> ${var%Pattern} Remove from $var the shortest part of $Pattern that matches the back end of $var

this is intended to get rid of perl dependency, see #14

see http://tldp.org/LDP/abs/html/parameter-substitution.html