### PR TITLE
Remove trailing slash except for '/' mountpoints

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -176,7 +176,7 @@ if [ $# -ne 3 ] ; then
 fi
 
 # Remove trailing slash
-mp=${1%/}
+mp=$(readlink -f $1)
 prefix=$2
 cnt=$(( $3+1 ))
 


### PR DESCRIPTION
btrfs-snap is currently broken when used against root filesystems. For example, invoking `.../btrfs-snap -r / daily 3` results in the following message:

```
btrfs subvolume show: too few arguments
usage: btrfs subvolume show <subvol-path>

    Show more information of the subvolume

ERROR:  is not a btrfs mountpoint (or old version of btrfs-tools, try > 0.19)
```

This broke in commit 30ef9f3, which set `mp` incorrectly for root mountpoints, causing `mp` to be set to `''` instead of `'/'`. Switching to using `readlink` to fix this, which is more robust than using string manipulation.