### PR TITLE
Replace use of bash primitive for removing trailing slashes with a

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -175,8 +175,8 @@ if [ $# -ne 3 ] ; then
     exit 1
 fi
 
-# Remove trailing slash
-mp=${1%/}
+# Canonicalize the mountpoint path (strip trailing slashes, etc)
+mp=$(realpath -m $1)
 prefix=$2
 cnt=$(( $3+1 ))
 

--- a/btrfs-snap
+++ b/btrfs-snap
@@ -192,8 +192,7 @@ function log.error() {
 }
 
 # Verify that the path is either a valid btrfs mountpoint
-mount -t btrfs | cut -d " " -f 3 | grep "^${mp}$" > /dev/null
-if [ $? -ne 0 ] ; then
+if ! findmnt -t btrfs -T "${mp}" &> /dev/null; then
     # or a valid snapshot matching mp
     btrfs subvolume show $mp | grep "${mp}$" > /dev/null
     if [ $? -ne 0 ] ; then


### PR DESCRIPTION
call to realpath.  realpath will strip trailing slashes as well as
otherwise normalize the path.  The prior approach would fail for paths
that were simply "/" turning mp into the empty string and failing the
script.