### PR TITLE
Fixed #23, fixed exception if called with e.x. /btrfs/system/@root

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -176,7 +176,7 @@ if [ $# -ne 3 ] ; then
 fi
 
 # Remove trailing slash
-mp=${1%/}
+mp=$(realpath -s $1)
 prefix=$2
 cnt=$(( $3+1 ))
 
@@ -195,7 +195,7 @@ function log.error() {
 mount -t btrfs | cut -d " " -f 3 | grep "^${mp}$" > /dev/null
 if [ $? -ne 0 ] ; then
     # or a valid snapshot matching mp
-    btrfs subvolume show $mp | grep "${mp}$" > /dev/null
+    btrfs subvolume show $mp | grep $(basename $mp) > /dev/null
     if [ $? -ne 0 ] ; then
         log.error "${mp} is not a btrfs mountpoint (or old version of btrfs-tools, try > 0.19)"
         exit 1;


### PR DESCRIPTION
* fixed #23
* Calling btrfs-snap `btrfs-snap -r -c -B /btrfs/system/snapshots
/btrfs/system/@root root_daily 7` throws `ERROR: /btrfs/system/@root is
not a btrfs mountpoint (or old version of btrfs-tools, try > 0.19)`.
Fixed #24.