### PR TITLE
prevent exit code 1 when deleting a snapshot in quiet mode (-q)

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -182,7 +182,10 @@ cnt=$(( $3+1 ))
 
 function log.info() {
     logger -p ${LOG_FACILITY}.info -t ${prog} "$1"
-    test -z "$quiet" && echo "$1"
+    if test -z "$quiet"
+    then
+        echo "$1"
+    fi
 }
 
 function log.error() {


### PR DESCRIPTION
When in quiet mode (i.e., ``-q`` is given) false negative exit codes might occur.
For example, when snapshots have to be deleted due to rotation.
This is especially annoying with (various) cron (implementations), because non-zero exit codes trigger an email being sent although no actual error occurred.
The cause might be the line ``test -z "$quiet" && echo "$1"`` in ``function log.info()`` (e.g., in 1.7.3: https://github.com/jf647/btrfs-snap/blob/7126515e2259c24b29a2a8ba272e7917db5a703c/btrfs-snap#L183-L186) which does not "mask" negative exit codes of ``test``.