### PR TITLE
compatiblity for btrfs-tools 4.12

### DIFF
--- a/btrfs-snap
+++ b/btrfs-snap
@@ -195,7 +195,7 @@ function log.error() {
 mount -t btrfs | cut -d " " -f 3 | grep "^${mp}$" > /dev/null
 if [ $? -ne 0 ] ; then
     # or a valid snapshot matching mp
-    btrfs subvolume show $mp | grep "${mp}$" > /dev/null
+    btrfs subvolume show $mp > /dev/null
     if [ $? -ne 0 ] ; then
         log.error "${mp} is not a btrfs mountpoint (or old version of btrfs-tools, try > 0.19)"
         exit 1;


### PR DESCRIPTION
With btrfs-tools 4.12 (e.g., as in Debian 10/buster/testing), mount points are not detected properly anymore, since the output of ``btrfs subvolume show`` changed significantly. Specifically, the mount point is no longer mentioned in the output. I also briefly tested the tiny change with btrfs-tools 3.17.
Supersedes #16